### PR TITLE
feat: `scope review` — end-of-day summary

### DIFF
--- a/src/cli/review.ts
+++ b/src/cli/review.ts
@@ -1,0 +1,212 @@
+import chalk from "chalk";
+import { loadConfig, configExists } from "../store/config.js";
+import { loadSnapshot } from "../store/snapshot.js";
+import { scanAllRepos } from "../sources/git.js";
+import { scanAssignedIssues } from "../sources/issues.js";
+import { getTodayCommits, getTodayPRActivity, getTodayIssueActivity } from "../sources/activity.js";
+import type { RepoActivity, PRActivity, IssueActivity } from "../sources/activity.js";
+
+interface ReviewOptions {
+  json?: boolean;
+}
+
+interface ReviewOutput {
+  done: string[];
+  stillOpen: string[];
+  tomorrow: string[];
+  stats: { doneCount: number; carryOverCount: number };
+}
+
+export async function reviewCommand(options: ReviewOptions): Promise<void> {
+  if (!configExists()) {
+    console.log(
+      chalk.yellow("  Scope isn't set up yet. Run `scope onboard` to get started.\n")
+    );
+    process.exit(1);
+  }
+
+  const config = loadConfig();
+
+  if (config.repos.length === 0) {
+    console.log(
+      chalk.yellow("  No repos configured. Run `scope config git` to add some.\n")
+    );
+    process.exit(1);
+  }
+
+  // Gather today's activity across all repos
+  const commitActivities: RepoActivity[] = [];
+  const prActivities: PRActivity[] = [];
+  const issueActivities: IssueActivity[] = [];
+
+  for (const repoPath of config.repos) {
+    const [commits, prs, issues] = await Promise.all([
+      getTodayCommits(repoPath),
+      getTodayPRActivity(repoPath),
+      getTodayIssueActivity(repoPath),
+    ]);
+    if (commits && commits.commitsToday > 0) commitActivities.push(commits);
+    if (prs) prActivities.push(prs);
+    if (issues) issueActivities.push(issues);
+  }
+
+  // Build "done" items
+  const done: string[] = [];
+
+  for (const activity of commitActivities) {
+    const summary = activity.commitMessages.length <= 3
+      ? activity.commitMessages.join(", ")
+      : `${activity.commitMessages.slice(0, 3).join(", ")}…`;
+    done.push(
+      `${activity.commitsToday} commit${activity.commitsToday > 1 ? "s" : ""} on ${activity.repo} (${summary})`
+    );
+  }
+
+  for (const pr of prActivities) {
+    for (const m of pr.merged) {
+      done.push(`PR #${m.number} merged on ${pr.repo} — ${m.title}`);
+    }
+    for (const o of pr.opened) {
+      done.push(`PR #${o.number} opened on ${pr.repo} — ${o.title}`);
+    }
+    for (const c of pr.closed) {
+      done.push(`PR #${c.number} closed on ${pr.repo} — ${c.title}`);
+    }
+  }
+
+  for (const issue of issueActivities) {
+    for (const c of issue.closed) {
+      done.push(`Issue #${c.number} closed on ${issue.repo} — ${c.title}`);
+    }
+  }
+
+  // Build "still open" — compare against morning snapshot
+  const stillOpen: string[] = [];
+  const snapshot = loadSnapshot();
+
+  if (snapshot) {
+    // Get current state of repos
+    const currentSignals = await scanAllRepos(config.repos);
+    const currentIssues = await scanAssignedIssues();
+
+    // Check which morning NOW/TODAY items are still unresolved
+    const morningItems = [...snapshot.now, ...snapshot.today];
+
+    for (const item of morningItems) {
+      if (item.source === "calendar") continue; // Meetings are done once past
+
+      if (item.source === "git") {
+        // Check if repo still has uncommitted work
+        const signal = currentSignals.find((s) => s.repo === item.label);
+        if (signal && signal.uncommittedFiles > 0) {
+          stillOpen.push(`${item.label} — ${signal.uncommittedFiles} uncommitted file${signal.uncommittedFiles > 1 ? "s" : ""}`);
+        }
+      }
+
+      if (item.source === "pr") {
+        // Check if PR is still open
+        const prMatch = item.label.match(/PR #(\d+) on (.+)/);
+        if (prMatch) {
+          const prNum = parseInt(prMatch[1], 10);
+          const repoName = prMatch[2];
+          const signal = currentSignals.find((s) => s.repo === repoName);
+          if (signal) {
+            const prStillOpen = signal.openPRs.find((p) => p.number === prNum);
+            if (prStillOpen) {
+              stillOpen.push(`${item.label} — ${item.detail}`);
+            }
+          }
+        }
+      }
+
+      if (item.source === "issue") {
+        // Check if issue is still in the open list
+        const issueMatch = item.label.match(/Issue #(\d+)/);
+        if (issueMatch) {
+          const issueNum = parseInt(issueMatch[1], 10);
+          const stillExists = currentIssues.issues.find((i) => i.number === issueNum);
+          if (stillExists) {
+            stillOpen.push(`${item.label} — still open`);
+          }
+        }
+      }
+    }
+  }
+
+  // Build "tomorrow" suggestions
+  const tomorrow: string[] = [];
+
+  // Stale PRs that need attention
+  const currentSignals = await scanAllRepos(config.repos);
+  for (const signal of currentSignals) {
+    for (const pr of signal.openPRs) {
+      if (pr.ageDays > 5) {
+        tomorrow.push(`Follow up on PR #${pr.number} on ${signal.repo} (${Math.round(pr.ageDays)}d old)`);
+      }
+    }
+  }
+
+  // Stale issues
+  const currentIssues = await scanAssignedIssues();
+  const staleIssues = currentIssues.issues.filter((i) => i.ageDays > 7);
+  if (staleIssues.length > 0) {
+    tomorrow.push(`${staleIssues.length} issue${staleIssues.length > 1 ? "s" : ""} trending stale across repos`);
+  }
+
+  const stats = {
+    doneCount: done.length,
+    carryOverCount: stillOpen.length,
+  };
+
+  const output: ReviewOutput = { done, stillOpen, tomorrow, stats };
+
+  // Output
+  if (options.json) {
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log("");
+
+  if (done.length === 0 && stillOpen.length === 0) {
+    console.log(chalk.dim("  Quiet day. No activity detected across watched repos.\n"));
+    return;
+  }
+
+  // DONE TODAY
+  if (done.length > 0) {
+    console.log(chalk.bold("  DONE TODAY"));
+    console.log(chalk.dim("  ──────────"));
+    for (const item of done) {
+      console.log(`  ${chalk.green("✓")} ${item}`);
+    }
+    console.log("");
+  }
+
+  // STILL OPEN
+  if (stillOpen.length > 0) {
+    console.log(chalk.bold("  STILL OPEN"));
+    console.log(chalk.dim("  ──────────"));
+    for (const item of stillOpen) {
+      console.log(`  ${chalk.yellow("→")} ${item}`);
+    }
+    console.log("");
+  }
+
+  // TOMORROW
+  if (tomorrow.length > 0) {
+    console.log(chalk.bold("  TOMORROW"));
+    console.log(chalk.dim("  ────────"));
+    for (const item of tomorrow) {
+      console.log(`  📋 ${item}`);
+    }
+    console.log("");
+  }
+
+  // Summary line
+  console.log(
+    chalk.dim(
+      `  ─────────────\n  ${stats.doneCount} item${stats.doneCount !== 1 ? "s" : ""} done · ${stats.carryOverCount} carrying over\n`
+    )
+  );
+}

--- a/src/cli/today.ts
+++ b/src/cli/today.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { loadConfig, configExists } from "../store/config.js";
+import { saveSnapshot } from "../store/snapshot.js";
 import { scanAllRepos } from "../sources/git.js";
 import { getCalendarToday } from "../sources/calendar.js";
 import { scanAssignedIssues } from "../sources/issues.js";
@@ -56,6 +57,9 @@ export async function todayCommand(options: TodayOptions): Promise<void> {
 
   // Prioritize
   const result = prioritize(gitSignals, events, freeBlocks, issueScan.issues);
+
+  // Save snapshot for scope review
+  saveSnapshot(result.now, result.today);
 
   // Output
   if (options.json) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { contextCommand } from "./cli/context.js";
 import { statusCommand } from "./cli/status.js";
 import { onboardCommand } from "./cli/onboard.js";
 import { configCommand } from "./cli/config.js";
+import { reviewCommand } from "./cli/review.js";
 import { notificationsCommand } from "./cli/notifications.js";
 import { daemonCommand } from "./cli/daemon.js";
 
@@ -45,6 +46,12 @@ program
   .description("Overview of all watched projects")
   .option("--json", "Output as JSON")
   .action(statusCommand);
+
+program
+  .command("review")
+  .description("End-of-day summary — what got done, what's carrying over")
+  .option("--json", "Output as JSON")
+  .action(reviewCommand);
 
 program
   .command("config [key] [value]")

--- a/src/sources/activity.ts
+++ b/src/sources/activity.ts
@@ -1,0 +1,142 @@
+import { simpleGit } from "simple-git";
+import { existsSync } from "node:fs";
+
+export interface RepoActivity {
+  repo: string;
+  commitsToday: number;
+  commitMessages: string[];
+  filesChanged: number;
+}
+
+export interface PRActivity {
+  repo: string;
+  merged: Array<{ number: number; title: string }>;
+  opened: Array<{ number: number; title: string }>;
+  closed: Array<{ number: number; title: string }>;
+}
+
+export interface IssueActivity {
+  repo: string;
+  closed: Array<{ number: number; title: string }>;
+}
+
+export async function getTodayCommits(repoPath: string): Promise<RepoActivity | null> {
+  if (!existsSync(repoPath)) return null;
+
+  const git = simpleGit(repoPath);
+
+  try {
+    const isRepo = await git.checkIsRepo();
+    if (!isRepo) return null;
+
+    const repoName = repoPath.split("/").pop() || repoPath;
+
+    // Get today's commits
+    const log = await git.log(["--since=midnight", "--all"]);
+
+    if (!log.all || log.all.length === 0) {
+      return { repo: repoName, commitsToday: 0, commitMessages: [], filesChanged: 0 };
+    }
+
+    const commitMessages = log.all.map((c) => c.message.split("\n")[0]);
+
+    // Get files changed today
+    let filesChanged = 0;
+    try {
+      const diffStat = await git.diff(["--stat", "--since=midnight", "HEAD"]);
+      // Count lines that look like file changes (contain |)
+      filesChanged = diffStat.split("\n").filter((l) => l.includes("|")).length;
+    } catch {
+      // Fallback: estimate from commit count
+      filesChanged = 0;
+    }
+
+    return {
+      repo: repoName,
+      commitsToday: log.all.length,
+      commitMessages,
+      filesChanged,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function getTodayPRActivity(repoPath: string): Promise<PRActivity | null> {
+  const repoName = repoPath.split("/").pop() || repoPath;
+
+  try {
+    const { execSync } = await import("node:child_process");
+    const today = new Date().toISOString().split("T")[0];
+
+    // Merged today
+    let merged: PRActivity["merged"] = [];
+    try {
+      const mergedRaw = execSync(
+        `gh pr list --state merged --json number,title,mergedAt --limit 20`,
+        { cwd: repoPath, encoding: "utf-8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"] }
+      );
+      const mergedPrs = JSON.parse(mergedRaw) as Array<{ number: number; title: string; mergedAt: string }>;
+      merged = mergedPrs
+        .filter((pr) => pr.mergedAt && pr.mergedAt.startsWith(today))
+        .map((pr) => ({ number: pr.number, title: pr.title }));
+    } catch { /* no merged PRs or gh not available */ }
+
+    // Opened today
+    let opened: PRActivity["opened"] = [];
+    try {
+      const openedRaw = execSync(
+        `gh pr list --state open --json number,title,createdAt --limit 20`,
+        { cwd: repoPath, encoding: "utf-8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"] }
+      );
+      const openedPrs = JSON.parse(openedRaw) as Array<{ number: number; title: string; createdAt: string }>;
+      opened = openedPrs
+        .filter((pr) => pr.createdAt && pr.createdAt.startsWith(today))
+        .map((pr) => ({ number: pr.number, title: pr.title }));
+    } catch { /* no opened PRs or gh not available */ }
+
+    // Closed today (not merged)
+    let closed: PRActivity["closed"] = [];
+    try {
+      const closedRaw = execSync(
+        `gh pr list --state closed --json number,title,closedAt,mergedAt --limit 20`,
+        { cwd: repoPath, encoding: "utf-8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"] }
+      );
+      const closedPrs = JSON.parse(closedRaw) as Array<{ number: number; title: string; closedAt: string; mergedAt: string | null }>;
+      closed = closedPrs
+        .filter((pr) => pr.closedAt && pr.closedAt.startsWith(today) && !pr.mergedAt)
+        .map((pr) => ({ number: pr.number, title: pr.title }));
+    } catch { /* no closed PRs or gh not available */ }
+
+    if (merged.length === 0 && opened.length === 0 && closed.length === 0) return null;
+
+    return { repo: repoName, merged, opened, closed };
+  } catch {
+    return null;
+  }
+}
+
+export async function getTodayIssueActivity(repoPath: string): Promise<IssueActivity | null> {
+  const repoName = repoPath.split("/").pop() || repoPath;
+
+  try {
+    const { execSync } = await import("node:child_process");
+    const today = new Date().toISOString().split("T")[0];
+
+    const result = execSync(
+      `gh issue list --state closed --json number,title,closedAt --limit 20`,
+      { cwd: repoPath, encoding: "utf-8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"] }
+    );
+
+    const issues = JSON.parse(result) as Array<{ number: number; title: string; closedAt: string }>;
+    const closedToday = issues
+      .filter((i) => i.closedAt && i.closedAt.startsWith(today))
+      .map((i) => ({ number: i.number, title: i.title }));
+
+    if (closedToday.length === 0) return null;
+
+    return { repo: repoName, closed: closedToday };
+  } catch {
+    return null;
+  }
+}

--- a/src/store/snapshot.ts
+++ b/src/store/snapshot.ts
@@ -1,0 +1,40 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { ScoredItem } from "../engine/prioritize.js";
+
+const SNAPSHOTS_DIR = join(homedir(), ".scope", "snapshots");
+
+function todayKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export interface DaySnapshot {
+  date: string;
+  timestamp: string;
+  now: ScoredItem[];
+  today: ScoredItem[];
+}
+
+export function saveSnapshot(now: ScoredItem[], today: ScoredItem[]): void {
+  mkdirSync(SNAPSHOTS_DIR, { recursive: true });
+  const snapshot: DaySnapshot = {
+    date: todayKey(),
+    timestamp: new Date().toISOString(),
+    now,
+    today,
+  };
+  const file = join(SNAPSHOTS_DIR, `${todayKey()}.json`);
+  writeFileSync(file, JSON.stringify(snapshot, null, 2));
+}
+
+export function loadSnapshot(): DaySnapshot | null {
+  const file = join(SNAPSHOTS_DIR, `${todayKey()}.json`);
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf-8")) as DaySnapshot;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #1

## What

Adds `scope review` — the evening counterpart to `scope today`. Reads the same signals but looks backward at what happened today.

## Output

```
$ scope review

  DONE TODAY
  ──────────
  ✓ 4 commits on fureworks/scope (issues source, daemon)
  ✓ PR #12 merged on fureworks.com
  ✓ Issue #3 closed on scope

  STILL OPEN
  ──────────
  → PR #8 on api-service — still waiting on review
  → 2 uncommitted files in scope-app

  TOMORROW
  ────────
  📋 Follow up on PR #8 on api-service (6d old)
  📋 3 issues trending stale across repos

  ─────────────
  4 items done · 2 carrying over
```

## How it works

1. **Activity scanning** (`src/sources/activity.ts`): queries each repo for today's commits (`git log --since=midnight`), merged/opened/closed PRs (`gh pr list`), and closed issues (`gh issue list`)

2. **Morning snapshot** (`src/store/snapshot.ts`): `scope today` now saves its NOW/TODAY items to `~/.scope/snapshots/YYYY-MM-DD.json`. `scope review` loads this to compare against current state — items still unresolved become "carry-over"

3. **Tomorrow suggestions**: surfaces stale PRs (>5 days) and trending stale issues (>7 days) as next-day priorities

## Files changed

- `src/cli/review.ts` — review command handler
- `src/sources/activity.ts` — today's commits, PR activity, issue activity
- `src/store/snapshot.ts` — save/load daily snapshots
- `src/cli/today.ts` — now saves snapshot on run
- `src/index.ts` — register review command

## Flags

- `--json` — machine-readable output