### PR TITLE
feat: Active suppression — show ignored items (#4)

### DIFF
--- a/src/cli/today.ts
+++ b/src/cli/today.ts
@@ -69,16 +69,6 @@ export async function todayCommand(options: TodayOptions): Promise<void> {
 
   console.log("");
 
-  if (result.now.length === 0 && result.today.length === 0) {
-    console.log(chalk.green("  ✓ Nothing urgent. You're clear.\n"));
-    if (result.laterCount > 0) {
-      console.log(
-        chalk.dim(`  ${result.laterCount} low-priority items → scope status\n`)
-      );
-    }
-    return;
-  }
-
   // NOW section
   if (result.now.length > 0) {
     console.log(chalk.bold("  NOW"));
@@ -101,6 +91,24 @@ export async function todayCommand(options: TodayOptions): Promise<void> {
     console.log("");
   }
 
+  // IGNORED section
+  if (result.ignored.length > 0) {
+    console.log(chalk.bold("  IGNORED"));
+    console.log(chalk.dim("  ───────"));
+    const shown = result.ignored.slice(0, 10);
+    for (const item of shown) {
+      console.log(chalk.dim(`  ✗ ${item.label} — ${item.reason}`));
+    }
+    if (result.ignored.length > shown.length) {
+      console.log(chalk.dim(`  and ${result.ignored.length - shown.length} more`));
+    }
+    console.log("");
+  }
+
+  if (result.now.length === 0) {
+    console.log(chalk.dim("  Nothing else needs you today.\n"));
+  }
+
   // Suggestions
   if (result.suggestions.length > 0) {
     for (const suggestion of result.suggestions) {
@@ -110,9 +118,9 @@ export async function todayCommand(options: TodayOptions): Promise<void> {
   }
 
   // Later count
-  if (result.laterCount > 0) {
+  if (result.ignored.length > 0) {
     console.log(
-      chalk.dim(`  ${result.laterCount} other items can wait → scope status\n`)
+      chalk.dim(`  ${result.ignored.length} other items can wait → scope status\n`)
     );
   }
 }

--- a/src/engine/prioritize.ts
+++ b/src/engine/prioritize.ts
@@ -16,12 +16,17 @@ export interface ScoredItem {
 export interface PrioritizedOutput {
   now: ScoredItem[];
   today: ScoredItem[];
-  laterCount: number;
+  ignored: Array<{ label: string; reason: string }>;
+  readonly laterCount: number;
   freeBlocks: FreeBlock[];
   suggestions: string[];
 }
 
-function scorePR(pr: PRInfo, repoName: string): ScoredItem {
+interface CandidateItem extends ScoredItem {
+  suppressionReason?: string;
+}
+
+function scorePR(pr: PRInfo, repoName: string): CandidateItem {
   let score = 0;
   const details: string[] = [];
 
@@ -53,6 +58,15 @@ function scorePR(pr: PRInfo, repoName: string): ScoredItem {
 
   const priority: Priority = score >= 8 ? "now" : score >= 4 ? "today" : "later";
 
+  const suppressionReason =
+    priority === "later"
+      ? pr.ageDays <= 2 && !pr.reviewRequested
+        ? "Fresh, no one's waiting"
+        : pr.ciStatus === "pass"
+          ? "On track, CI green"
+          : undefined
+      : undefined;
+
   return {
     priority,
     score,
@@ -60,10 +74,11 @@ function scorePR(pr: PRInfo, repoName: string): ScoredItem {
     label: `PR #${pr.number} on ${repoName}`,
     detail: `${pr.title} — ${details.join(", ")}`,
     source: "pr",
+    suppressionReason,
   };
 }
 
-function scoreRepoWork(signal: GitSignal): ScoredItem | null {
+function scoreRepoWork(signal: GitSignal): CandidateItem | null {
   if (signal.uncommittedFiles === 0) return null;
 
   let score = 0;
@@ -88,8 +103,6 @@ function scoreRepoWork(signal: GitSignal): ScoredItem | null {
     score += 1;
   }
 
-  if (score < 2) return null; // Don't surface fresh uncommitted work
-
   const priority: Priority = score >= 8 ? "now" : score >= 4 ? "today" : "later";
 
   return {
@@ -99,6 +112,8 @@ function scoreRepoWork(signal: GitSignal): ScoredItem | null {
     label: `${signal.repo}`,
     detail: details.join(", "),
     source: "git",
+    suppressionReason:
+      priority === "later" ? "Recently touched, nothing stale" : undefined,
   };
 }
 
@@ -140,7 +155,7 @@ function scoreCalendarEvent(event: CalendarEvent): ScoredItem | null {
   };
 }
 
-function scoreIssue(issue: IssueSignal): ScoredItem | null {
+function scoreIssue(issue: IssueSignal): CandidateItem {
   let score = 0;
   const details: string[] = [];
 
@@ -160,8 +175,6 @@ function scoreIssue(issue: IssueSignal): ScoredItem | null {
     details.push("priority label");
   }
 
-  if (score === 0) return null;
-
   const priority: Priority = score >= 8 ? "now" : score >= 4 ? "today" : "later";
   const labels = issue.labels.length > 0 ? ` [${issue.labels.join(", ")}]` : "";
 
@@ -172,6 +185,10 @@ function scoreIssue(issue: IssueSignal): ScoredItem | null {
     label: `Issue #${issue.number} on ${issue.repo}`,
     detail: `${issue.title}${labels}${details.length > 0 ? ` — ${details.join(", ")}` : ""}`,
     source: "issue",
+    suppressionReason:
+      priority === "later" && issue.ageDays < 7 && !hasPriorityLabel
+        ? "Less than a week old, no priority label"
+        : undefined,
   };
 }
 
@@ -181,7 +198,7 @@ export function prioritize(
   freeBlocks: FreeBlock[],
   issues: IssueSignal[]
 ): PrioritizedOutput {
-  const allItems: ScoredItem[] = [];
+  const allItems: CandidateItem[] = [];
 
   // Score calendar events
   for (const event of calendarEvents) {
@@ -218,9 +235,17 @@ export function prioritize(
   const now = allNow.slice(0, 3);
   const todayOverflow = allNow.slice(3);
   const today = [...todayOverflow, ...allToday].slice(0, 5);
-  const laterCount =
-    allLater.length +
-    Math.max(0, todayOverflow.length + allToday.length - 5);
+  const capped = [...todayOverflow, ...allToday].slice(5);
+  const ignored = [
+    ...allLater.map((item) => ({
+      label: item.label,
+      reason: item.suppressionReason ?? "Lower priority than your top items",
+    })),
+    ...capped.map((item) => ({
+      label: item.label,
+      reason: "Lower priority than your top items",
+    })),
+  ];
 
   // Generate suggestions
   const suggestions: string[] = [];
@@ -253,5 +278,14 @@ export function prioritize(
     }
   }
 
-  return { now, today, laterCount, freeBlocks, suggestions };
+  return {
+    now,
+    today,
+    ignored,
+    get laterCount() {
+      return this.ignored.length;
+    },
+    freeBlocks,
+    suggestions,
+  };
 }


### PR DESCRIPTION
Closes #4

Shows what was deliberately excluded from NOW/TODAY and why.

```
IGNORED (5 items)
✗ PR #2 on docs — fresh, no one's waiting
✗ 2 issues on scope — nice-to-have, < 1 week old

Nothing else needs you today.
```

The value is confident exclusion — permission to focus.