### PR TITLE
feat: scope snooze / scope mute (#6)

### DIFF
--- a/src/cli/snooze.ts
+++ b/src/cli/snooze.ts
@@ -1,0 +1,224 @@
+import chalk from "chalk";
+import {
+  loadMuted,
+  saveMuted,
+  type MuteEntry,
+  type SnoozeEntry,
+} from "../store/muted.js";
+
+interface SnoozeOptions {
+  until: string;
+}
+
+interface MuteOptions {
+  list?: boolean;
+  clear?: string;
+}
+
+const DAY_NAMES = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+] as const;
+
+export function parseUntilDate(input: string): Date {
+  const normalized = input.trim().toLowerCase();
+  const now = new Date();
+
+  if (normalized === "tomorrow") {
+    const tomorrow = new Date(now);
+    tomorrow.setHours(0, 0, 0, 0);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return tomorrow;
+  }
+
+  const dayIndex = DAY_NAMES.indexOf(
+    normalized as (typeof DAY_NAMES)[number]
+  );
+  if (dayIndex >= 0) {
+    const target = new Date(now);
+    target.setHours(0, 0, 0, 0);
+    const delta = (dayIndex - target.getDay() + 7) % 7 || 7;
+    target.setDate(target.getDate() + delta);
+    return target;
+  }
+
+  const relative = normalized.match(/^(\d+)([dw])$/);
+  if (relative) {
+    const amount = Number.parseInt(relative[1], 10);
+    const unit = relative[2];
+    const days = unit === "w" ? amount * 7 : amount;
+    const target = new Date(now);
+    target.setDate(target.getDate() + days);
+    return target;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+    const target = new Date(`${normalized}T00:00:00`);
+    if (!Number.isNaN(target.getTime())) {
+      return target;
+    }
+  }
+
+  throw new Error(
+    "Invalid --until value. Use: tomorrow, monday-sunday, 3d, 1w, or YYYY-MM-DD."
+  );
+}
+
+function isValidItemId(id: string): boolean {
+  return (
+    /^(pr|issue):[^#\s]+#\d+$/.test(id) ||
+    /^git:[^\s]+$/.test(id)
+  );
+}
+
+function upsertSnooze(snoozed: SnoozeEntry[], entry: SnoozeEntry): SnoozeEntry[] {
+  return [...snoozed.filter((existing) => existing.id !== entry.id), entry];
+}
+
+function upsertMute(muted: MuteEntry[], entry: MuteEntry): MuteEntry[] {
+  return [...muted.filter((existing) => existing.id !== entry.id), entry];
+}
+
+function printList(): void {
+  const store = loadMuted();
+
+  console.log("");
+  console.log(chalk.bold("  Muted Items"));
+  if (store.muted.length === 0) {
+    console.log(chalk.dim("  (none)"));
+  } else {
+    for (const entry of store.muted) {
+      console.log(`  - ${entry.id} ${chalk.dim(`(muted ${entry.created})`)}`);
+    }
+  }
+
+  console.log("");
+  console.log(chalk.bold("  Snoozed Items"));
+  if (store.snoozed.length === 0) {
+    console.log(chalk.dim("  (none)"));
+  } else {
+    for (const entry of store.snoozed) {
+      console.log(`  - ${entry.id} ${chalk.dim(`(until ${entry.until})`)}`);
+    }
+  }
+  console.log("");
+}
+
+function clearItem(id: string): void {
+  if (!isValidItemId(id)) {
+    console.log(
+      chalk.yellow(
+        "  Invalid item id. Use pr:repo#123, issue:repo#123, or git:repo.\n"
+      )
+    );
+    return;
+  }
+
+  const store = loadMuted();
+  const next = {
+    muted: store.muted.filter((entry) => entry.id !== id),
+    snoozed: store.snoozed.filter((entry) => entry.id !== id),
+  };
+  saveMuted(next);
+
+  if (
+    next.muted.length === store.muted.length &&
+    next.snoozed.length === store.snoozed.length
+  ) {
+    console.log(chalk.dim(`  No entry found for ${id}\n`));
+    return;
+  }
+
+  console.log(chalk.green(`  Cleared: ${id}\n`));
+}
+
+export async function snoozeCommand(
+  itemId: string,
+  options: SnoozeOptions
+): Promise<void> {
+  if (!isValidItemId(itemId)) {
+    console.log(
+      chalk.yellow(
+        "  Invalid item id. Use pr:repo#123, issue:repo#123, or git:repo.\n"
+      )
+    );
+    return;
+  }
+
+  let untilDate: Date;
+  try {
+    untilDate = parseUntilDate(options.until);
+  } catch (error) {
+    console.log(chalk.yellow(`  ${(error as Error).message}\n`));
+    return;
+  }
+
+  if (untilDate.getTime() <= Date.now()) {
+    console.log(chalk.yellow("  --until must resolve to a future time.\n"));
+    return;
+  }
+
+  const nowIso = new Date().toISOString();
+  const untilIso = untilDate.toISOString();
+  const store = loadMuted();
+
+  const next = {
+    muted: store.muted.filter((entry) => entry.id !== itemId),
+    snoozed: upsertSnooze(store.snoozed, {
+      id: itemId,
+      until: untilIso,
+      created: nowIso,
+    }),
+  };
+  saveMuted(next);
+
+  console.log(chalk.green(`  Snoozed ${itemId} until ${untilIso}\n`));
+}
+
+export async function muteCommand(
+  itemId: string | undefined,
+  options: MuteOptions
+): Promise<void> {
+  if (options.list) {
+    printList();
+    return;
+  }
+
+  if (options.clear) {
+    clearItem(options.clear);
+    return;
+  }
+
+  if (!itemId) {
+    console.log(
+      chalk.yellow(
+        "  Missing item id. Use: scope mute <item-id>, scope mute --list, or scope mute --clear <item-id>.\n"
+      )
+    );
+    return;
+  }
+
+  if (!isValidItemId(itemId)) {
+    console.log(
+      chalk.yellow(
+        "  Invalid item id. Use pr:repo#123, issue:repo#123, or git:repo.\n"
+      )
+    );
+    return;
+  }
+
+  const nowIso = new Date().toISOString();
+  const store = loadMuted();
+  const next = {
+    snoozed: store.snoozed.filter((entry) => entry.id !== itemId),
+    muted: upsertMute(store.muted, { id: itemId, created: nowIso }),
+  };
+  saveMuted(next);
+
+  console.log(chalk.green(`  Muted ${itemId}\n`));
+}

--- a/src/engine/prioritize.ts
+++ b/src/engine/prioritize.ts
@@ -1,6 +1,7 @@
 import { GitSignal, PRInfo } from "../sources/git.js";
 import { CalendarEvent, FreeBlock } from "../sources/calendar.js";
 import { IssueSignal } from "../sources/issues.js";
+import { isItemMuted } from "../store/muted.js";
 
 export type Priority = "now" | "today" | "later";
 
@@ -265,17 +266,22 @@ export function prioritize(
   // Score git repos
   for (const signal of gitSignals) {
     // Score uncommitted work
-    const repoItem = scoreRepoWork(signal);
+    const gitItemId = `git:${signal.repo}`;
+    const repoItem = isItemMuted(gitItemId) ? null : scoreRepoWork(signal);
     if (repoItem) allItems.push(repoItem);
 
     // Score PRs
     for (const pr of signal.openPRs) {
+      const prItemId = `pr:${signal.repo}#${pr.number}`;
+      if (isItemMuted(prItemId)) continue;
       allItems.push(scorePR(pr, signal.repo));
     }
   }
 
   // Score issues
   for (const issue of issues) {
+    const issueItemId = `issue:${issue.repo}#${issue.number}`;
+    if (isItemMuted(issueItemId)) continue;
     const scored = scoreIssue(issue);
     if (scored) allItems.push(scored);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { configCommand } from "./cli/config.js";
 import { reviewCommand } from "./cli/review.js";
 import { notificationsCommand } from "./cli/notifications.js";
 import { daemonCommand } from "./cli/daemon.js";
+import { muteCommand, snoozeCommand } from "./cli/snooze.js";
 
 const program = new Command();
 
@@ -69,5 +70,21 @@ program
   .option("--clear", "Clear all notifications")
   .option("--all", "Show all notifications (not just last 24h)")
   .action(notificationsCommand);
+
+program
+  .command("snooze <item>")
+  .description("Snooze an item until a future date")
+  .requiredOption(
+    "--until <date>",
+    "Until date: tomorrow, monday..sunday, 3d, 1w, or YYYY-MM-DD"
+  )
+  .action(snoozeCommand);
+
+program
+  .command("mute [item]")
+  .description("Mute an item permanently, list mutes, or clear an item")
+  .option("--list", "Show muted and snoozed items")
+  .option("--clear <item-id>", "Remove an item from muted/snoozed")
+  .action(muteCommand);
 
 program.parse();

--- a/src/store/muted.ts
+++ b/src/store/muted.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { ensureScopeDir, getScopeDir } from "./config.js";
+
+export interface SnoozeEntry {
+  id: string;
+  until: string;
+  created: string;
+}
+
+export interface MuteEntry {
+  id: string;
+  created: string;
+}
+
+export interface MutedStore {
+  snoozed: SnoozeEntry[];
+  muted: MuteEntry[];
+}
+
+const MUTED_PATH = join(getScopeDir(), "muted.json");
+
+function emptyStore(): MutedStore {
+  return { snoozed: [], muted: [] };
+}
+
+function normalizeStore(raw: unknown): MutedStore {
+  if (!raw || typeof raw !== "object") {
+    return emptyStore();
+  }
+
+  const maybeStore = raw as Partial<MutedStore>;
+  return {
+    snoozed: Array.isArray(maybeStore.snoozed) ? maybeStore.snoozed : [],
+    muted: Array.isArray(maybeStore.muted) ? maybeStore.muted : [],
+  };
+}
+
+function cleanExpiredSnoozes(store: MutedStore): MutedStore {
+  const now = Date.now();
+  return {
+    muted: store.muted,
+    snoozed: store.snoozed.filter((entry) => {
+      const untilMs = new Date(entry.until).getTime();
+      return Number.isFinite(untilMs) && untilMs > now;
+    }),
+  };
+}
+
+export function loadMuted(): MutedStore {
+  ensureScopeDir();
+  if (!existsSync(MUTED_PATH)) {
+    return emptyStore();
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(MUTED_PATH, "utf-8")) as unknown;
+    const normalized = normalizeStore(raw);
+    const cleaned = cleanExpiredSnoozes(normalized);
+
+    if (cleaned.snoozed.length !== normalized.snoozed.length) {
+      saveMuted(cleaned);
+    }
+
+    return cleaned;
+  } catch {
+    return emptyStore();
+  }
+}
+
+export function saveMuted(store: MutedStore): void {
+  ensureScopeDir();
+  writeFileSync(MUTED_PATH, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+}
+
+export function isItemMuted(id: string): boolean {
+  const store = loadMuted();
+  return (
+    store.muted.some((entry) => entry.id === id) ||
+    store.snoozed.some((entry) => entry.id === id)
+  );
+}


### PR DESCRIPTION
Closes #6

User override for false positives:

```bash
scope snooze pr:api-service#8 --until friday
scope mute issue:scope#12
scope mute --list
scope mute --clear issue:scope#12
```

Supports: named days, relative (3d, 1w), ISO dates.
Storage: ~/.scope/muted.json, auto-cleans expired snoozes.
Integrates with prioritization engine — muted items filtered before scoring.