### PR TITLE
feat: scope tune — scoring weight adjustment (#15)

### DIFF
--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -142,6 +142,7 @@ export async function onboardCommand(): Promise<void> {
     projects: {},
     calendar: { enabled: false, backend: "gws" },
     daemon: { enabled: false, intervalMinutes: 15 },
+    weights: { staleness: 1.0, blocking: 1.0, timePressure: 1.0, effort: 1.0 },
   };
 
   // Step 1: Git repos

--- a/src/cli/today.ts
+++ b/src/cli/today.ts
@@ -56,7 +56,7 @@ export async function todayCommand(options: TodayOptions): Promise<void> {
   }
 
   // Prioritize
-  const result = prioritize(gitSignals, events, freeBlocks, issueScan.issues);
+  const result = prioritize(gitSignals, events, freeBlocks, issueScan.issues, config.weights);
 
   const timeContext = getTimeContext();
 

--- a/src/cli/tune.ts
+++ b/src/cli/tune.ts
@@ -1,0 +1,79 @@
+import chalk from "chalk";
+import { loadConfig, saveConfig, DEFAULT_WEIGHTS, ScoringWeights } from "../store/config.js";
+
+interface TuneOptions {
+  show?: boolean;
+  reset?: boolean;
+  config?: boolean;
+}
+
+const VALID_KEYS = ["staleness", "blocking", "timePressure", "effort"] as const;
+
+export async function tuneCommand(
+  key: string | undefined,
+  value: string | undefined,
+  options: TuneOptions
+): Promise<void> {
+  const config = loadConfig();
+
+  if (options.show || (!key && !options.reset && !options.config)) {
+    console.log("");
+    console.log(chalk.bold("  Scoring Weights"));
+    console.log(chalk.dim("  ───────────────"));
+    for (const [k, v] of Object.entries(config.weights)) {
+      const isDefault = v === DEFAULT_WEIGHTS[k as keyof ScoringWeights];
+      const label = isDefault ? chalk.dim("(default)") : chalk.yellow("(custom)");
+      console.log(`  ${k}: ${v} ${label}`);
+    }
+    console.log("");
+    console.log(chalk.dim("  Multipliers on raw scores. 1.0 = default. Higher = more priority."));
+    console.log(chalk.dim("  Example: scope tune staleness 1.5 → stale items rank higher\n"));
+    return;
+  }
+
+  if (options.reset) {
+    config.weights = { ...DEFAULT_WEIGHTS };
+    saveConfig(config);
+    console.log("  ✓ Weights reset to defaults.\n");
+    return;
+  }
+
+  if (options.config) {
+    const editor = process.env.EDITOR || process.env.VISUAL || "vi";
+    const { execSync } = await import("node:child_process");
+    const { join } = await import("node:path");
+    const { homedir } = await import("node:os");
+    const configPath = join(homedir(), ".scope", "config.toml");
+    try {
+      execSync(`${editor} ${configPath}`, { stdio: "inherit" });
+      console.log("  ✓ Config saved.\n");
+    } catch {
+      console.log(chalk.red("  Failed to open editor.\n"));
+    }
+    return;
+  }
+
+  if (key && value) {
+    if (!VALID_KEYS.includes(key as typeof VALID_KEYS[number])) {
+      console.log(chalk.red(`  Unknown weight: ${key}`));
+      console.log(chalk.dim(`  Valid keys: ${VALID_KEYS.join(", ")}\n`));
+      process.exit(1);
+    }
+
+    const num = parseFloat(value);
+    if (isNaN(num) || num < 0 || num > 10) {
+      console.log(chalk.red(`  Invalid value: ${value}. Must be 0-10.\n`));
+      process.exit(1);
+    }
+
+    config.weights[key as keyof ScoringWeights] = num;
+    saveConfig(config);
+    console.log(`  ✓ ${key} set to ${num}\n`);
+    return;
+  }
+
+  if (key && !value) {
+    console.log(chalk.red(`  Missing value. Usage: scope tune ${key} <number>\n`));
+    process.exit(1);
+  }
+}

--- a/src/engine/prioritize.ts
+++ b/src/engine/prioritize.ts
@@ -2,6 +2,7 @@ import { GitSignal, PRInfo } from "../sources/git.js";
 import { CalendarEvent, FreeBlock } from "../sources/calendar.js";
 import { IssueSignal } from "../sources/issues.js";
 import { isItemMuted } from "../store/muted.js";
+import { ScoringWeights, DEFAULT_WEIGHTS } from "../store/config.js";
 
 export type Priority = "now" | "today" | "later";
 
@@ -253,7 +254,8 @@ export function prioritize(
   gitSignals: GitSignal[],
   calendarEvents: CalendarEvent[],
   freeBlocks: FreeBlock[],
-  issues: IssueSignal[]
+  issues: IssueSignal[],
+  weights: ScoringWeights = DEFAULT_WEIGHTS
 ): PrioritizedOutput {
   const allItems: CandidateItem[] = [];
 
@@ -284,6 +286,22 @@ export function prioritize(
     if (isItemMuted(issueItemId)) continue;
     const scored = scoreIssue(issue);
     if (scored) allItems.push(scored);
+  }
+
+  // Apply weight multipliers based on source type
+  for (const item of allItems) {
+    if (item.source === "git") {
+      item.score = Math.round(item.score * weights.staleness);
+    } else if (item.source === "pr") {
+      // PRs have both staleness and blocking components — use the higher weight
+      item.score = Math.round(item.score * Math.max(weights.staleness, weights.blocking));
+    } else if (item.source === "calendar") {
+      item.score = Math.round(item.score * weights.timePressure);
+    } else if (item.source === "issue") {
+      item.score = Math.round(item.score * weights.staleness);
+    }
+    // Recalculate priority tier after weight adjustment
+    item.priority = item.score >= 8 ? "now" : item.score >= 4 ? "today" : "later";
   }
 
   // Sort by score descending

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { daemonCommand } from "./cli/daemon.js";
 import { muteCommand, snoozeCommand } from "./cli/snooze.js";
 import { planCommand } from "./cli/plan.js";
 import { initCommand } from "./cli/init.js";
+import { tuneCommand } from "./cli/tune.js";
 
 const program = new Command();
 
@@ -91,6 +92,14 @@ program
   .option("--list", "Show muted and snoozed items")
   .option("--clear <item-id>", "Remove an item from muted/snoozed")
   .action(muteCommand);
+
+program
+  .command("tune [key] [value]")
+  .description("View or adjust scoring weights")
+  .option("--show", "Display current weights")
+  .option("--reset", "Reset weights to defaults")
+  .option("--config", "Open config in $EDITOR")
+  .action(tuneCommand);
 
 program
   .command("plan")

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -3,6 +3,20 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { parse as parseToml } from "toml";
 
+export interface ScoringWeights {
+  staleness: number;
+  blocking: number;
+  timePressure: number;
+  effort: number;
+}
+
+export const DEFAULT_WEIGHTS: ScoringWeights = {
+  staleness: 1.0,
+  blocking: 1.0,
+  timePressure: 1.0,
+  effort: 1.0,
+};
+
 export interface ScopeConfig {
   repos: string[];
   projects: Record<
@@ -21,6 +35,7 @@ export interface ScopeConfig {
     enabled: boolean;
     intervalMinutes: number;
   };
+  weights: ScoringWeights;
 }
 
 const SCOPE_DIR = join(homedir(), ".scope");
@@ -51,11 +66,14 @@ export function loadConfig(): ScopeConfig {
       projects: {},
       calendar: { enabled: false, backend: "gws" },
       daemon: { enabled: false, intervalMinutes: 15 },
+      weights: { ...DEFAULT_WEIGHTS },
     };
   }
 
   const raw = readFileSync(CONFIG_PATH, "utf-8");
   const parsed = parseToml(raw) as Partial<ScopeConfig>;
+
+  const parsedWeights = (parsed as Record<string, unknown>).weights as Partial<ScoringWeights> | undefined;
 
   return {
     repos: parsed.repos ?? [],
@@ -67,6 +85,12 @@ export function loadConfig(): ScopeConfig {
     daemon: {
       enabled: parsed.daemon?.enabled ?? false,
       intervalMinutes: parsed.daemon?.intervalMinutes ?? 15,
+    },
+    weights: {
+      staleness: parsedWeights?.staleness ?? DEFAULT_WEIGHTS.staleness,
+      blocking: parsedWeights?.blocking ?? DEFAULT_WEIGHTS.blocking,
+      timePressure: parsedWeights?.timePressure ?? DEFAULT_WEIGHTS.timePressure,
+      effort: parsedWeights?.effort ?? DEFAULT_WEIGHTS.effort,
     },
   };
 }
@@ -87,6 +111,15 @@ export function saveConfig(config: ScopeConfig): void {
   lines.push(`enabled = ${config.daemon.enabled}`);
   lines.push(`intervalMinutes = ${config.daemon.intervalMinutes}`);
   lines.push("");
+
+  if (config.weights) {
+    lines.push("[weights]");
+    lines.push(`staleness = ${config.weights.staleness}`);
+    lines.push(`blocking = ${config.weights.blocking}`);
+    lines.push(`timePressure = ${config.weights.timePressure}`);
+    lines.push(`effort = ${config.weights.effort}`);
+    lines.push("");
+  }
 
   for (const [name, project] of Object.entries(config.projects)) {
     lines.push(`[projects.${name}]`);


### PR DESCRIPTION
Closes #15

Adds configurable scoring weights (staleness, blocking, timePressure, effort) as multipliers on raw scores.

```bash
scope tune                  # show current weights
scope tune staleness 1.5    # stale items rank higher
scope tune --reset          # restore defaults
scope tune --config         # open in $EDITOR
```

Weights stored in config.toml, applied in prioritize() after raw scoring.