### PR TITLE
feat: confidence indicators — flag thin data (#16)

### DIFF
--- a/src/cli/today.ts
+++ b/src/cli/today.ts
@@ -112,7 +112,8 @@ export async function todayCommand(options: TodayOptions): Promise<void> {
     console.log(chalk.bold("  NOW"));
     console.log(chalk.dim("  ───"));
     for (const item of result.now) {
-      console.log(`  ${item.emoji} ${chalk.bold(item.label)}`);
+      const confTag = item.confidenceNote ? chalk.yellow(` (${item.confidenceNote})`) : "";
+      console.log(`  ${item.emoji} ${chalk.bold(item.label)}${confTag}`);
       console.log(`     ${chalk.dim(item.detail)}`);
       console.log(`     ${chalk.dim(`Why: ${item.reason}`)}`);
     }
@@ -124,7 +125,8 @@ export async function todayCommand(options: TodayOptions): Promise<void> {
     console.log(chalk.bold("  TODAY"));
     console.log(chalk.dim("  ────"));
     for (const item of result.today) {
-      console.log(`  ${item.emoji} ${chalk.bold(item.label)}`);
+      const confTag = item.confidenceNote ? chalk.yellow(` (${item.confidenceNote})`) : "";
+      console.log(`  ${item.emoji} ${chalk.bold(item.label)}${confTag}`);
       console.log(`     ${chalk.dim(item.detail)}`);
       console.log(`     ${chalk.dim(`Why: ${item.reason}`)}`);
     }

--- a/src/engine/prioritize.ts
+++ b/src/engine/prioritize.ts
@@ -12,6 +12,8 @@ export interface ScoredItem {
   label: string;
   detail: string;
   reason: string;
+  confidence: "high" | "medium" | "low";
+  confidenceNote?: string;
   source: "git" | "calendar" | "pr" | "issue";
 }
 
@@ -97,6 +99,12 @@ function scorePR(pr: PRInfo, repoName: string): CandidateItem {
           : undefined
       : undefined;
 
+  // Confidence: check for thin data
+  const missingContext: string[] = [];
+  if (pr.ciStatus === "unknown") missingContext.push("no CI status");
+  if (!pr.reviewRequested && pr.ageDays > 2) missingContext.push("no reviewer assigned");
+  const confidence: ScoredItem["confidence"] = missingContext.length >= 2 ? "low" : missingContext.length === 1 ? "medium" : "high";
+
   return {
     priority,
     score,
@@ -104,6 +112,8 @@ function scorePR(pr: PRInfo, repoName: string): CandidateItem {
     label: `PR #${pr.number} on ${repoName}`,
     detail: `${pr.title} — ${details.join(", ")}`,
     reason,
+    confidence,
+    confidenceNote: missingContext.length > 0 ? `low context: ${missingContext.join(", ")}` : undefined,
     source: "pr",
     suppressionReason,
   };
@@ -148,6 +158,7 @@ function scoreRepoWork(signal: GitSignal): CandidateItem | null {
     label: `${signal.repo}`,
     detail: details.join(", "),
     reason,
+    confidence: "high" as const, // git signals are always concrete
     source: "git",
     suppressionReason:
       priority === "later" ? "Recently touched, nothing stale" : undefined,
@@ -192,6 +203,7 @@ function scoreCalendarEvent(event: CalendarEvent): ScoredItem | null {
     label: `Meeting: ${event.title}`,
     detail: timeLabel,
     reason,
+    confidence: "high" as const, // calendar events are factual
     source: "calendar",
   };
 }
@@ -234,6 +246,11 @@ function scoreIssue(issue: IssueSignal): CandidateItem {
     reason = `Marked ${priorityLabel}. Assigned to you.`;
   }
 
+  // Confidence: issues missing labels or with no assignee context
+  const issueMissing: string[] = [];
+  if (issue.labels.length === 0) issueMissing.push("no labels");
+  const issueConfidence: ScoredItem["confidence"] = issueMissing.length > 0 ? "medium" : "high";
+
   return {
     priority,
     score,
@@ -241,6 +258,8 @@ function scoreIssue(issue: IssueSignal): CandidateItem {
     label: `Issue #${issue.number} on ${issue.repo}`,
     detail: `${issue.title}${labels}${details.length > 0 ? ` — ${details.join(", ")}` : ""}`,
     reason,
+    confidence: issueConfidence,
+    confidenceNote: issueMissing.length > 0 ? `low context: ${issueMissing.join(", ")}` : undefined,
     source: "issue",
     suppressionReason:
       priority === "later" && issue.ageDays < 7 && !priorityLabel


### PR DESCRIPTION
Closes #16

Adds confidence field to scored items. When data is thin, shows a yellow tag:

```
🔴 PR #8 on api-service (low context: no CI status, no reviewer)
```

PRs: flags missing CI status, missing reviewer. Issues: flags missing labels. Git/Calendar: always high confidence.