### PR TITLE
feat: add ops-radar handoff metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ $ scope today
   Nothing else needs you today.
 ```
 
+Important: `scope today` is an ops radar, not a build queue. It tells you what needs attention. A downstream agent can decide what is actually buildable.
+
 ## Commands
 
 | Command | What it does |
@@ -146,10 +148,47 @@ Scope reads from external tools. All are optional — missing integrations reduc
 
 See [WORKFLOW.md](./WORKFLOW.md) for habits that make Scope's output better — commit often, assign yourself, use labels, block focus time.
 
+## Machine-readable ops-radar output
+
+`scope today --json` returns a stable advisory shape for downstream tools. Each surfaced item includes fields such as:
+
+- `score`
+- `scoreBreakdown`
+- `whySurfaced`
+- `repoMomentum`
+- `coveredByOpenPr`
+- `blocked`
+- `blockedReason`
+- `freshnessCheckedAt`
+- `attentionLane`
+
+Example:
+
+```json
+{
+  "mode": "ops-radar",
+  "advisory": true,
+  "generatedAt": "2026-04-08T04:00:00.000Z",
+  "now": [
+    {
+      "label": "PR #18 on scope",
+      "score": 27,
+      "whySurfaced": ["review requested", "open 6 days"],
+      "attentionLane": "review",
+      "coveredByOpenPr": false,
+      "blocked": false
+    }
+  ]
+}
+```
+
+Use this as awareness input, not as proof that something should be built next.
+
 ## Philosophy
 
 - **Zero manual input.** Scope reads. It doesn't ask you to enter data.
 - **Confident exclusion.** The value isn't what's shown — it's what's hidden and why.
+- **Advisory, not authoritative.** Scope is the ops radar. It should not pretend to be the nightly build selector.
 - **Degraded mode is fine.** Only have git? Scope works. Add calendar? Better. Each integration is additive.
 - **CLI-first, local-first.** No accounts, no cloud, no tracking.
 - **No AI (v1).** Deterministic rules-based scoring. Transparent and predictable.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -38,7 +38,9 @@ This isn't about perfecting your workflow. It's about small habits that make Sco
 
 **Run `scope today` in the morning.** It saves a snapshot that `scope review` uses at end of day. No morning run = no carry-over comparison in the evening.
 
-**Don't fight the ranking.** If Scope says something is NOW and you disagree, that's useful information. Either the scoring needs tuning (`scope tune` in a future version), or you're avoiding something. Both are worth noticing.
+**Treat the ranking as ops radar.** If Scope says something is NOW and you disagree, that's useful information. Either the scoring needs tuning, or you're seeing buildability/context that Scope does not. Scope tells you what needs attention, not what must be built next.
+
+**Use `--json` for downstream tooling.** `scope today --json` exposes why an item surfaced, what lane it belongs to (`review`, `merge`, `nudge`, `investigate`), and whether it looks blocked or already covered by an open PR. That output is the handoff shape for a separate build selector.
 
 **Missing context is okay.** Scope works in degraded mode by design. No calendar? It still reads git. No `gh` CLI? It still shows uncommitted work. Start with what you have. Add integrations as they become useful.
 

--- a/src/engine/__tests__/prioritize.test.ts
+++ b/src/engine/__tests__/prioritize.test.ts
@@ -153,6 +153,43 @@ describe('prioritize', () => {
     });
   });
 
+  describe('ops-radar metadata', () => {
+    it('should expose machine-readable advisory metadata on surfaced items', () => {
+      const pr = makePR({ number: 1, ageDays: 20, reviewRequested: true });
+
+      const result = prioritize(
+        [makeGitSignal('repo', [pr])],
+        [], [], [], DEFAULT_WEIGHTS
+      );
+
+      const item = result.now.find(i => i.label.includes('#1'));
+      expect(result.mode).toBe('ops-radar');
+      expect(result.advisory).toBe(true);
+      expect(result.generatedAt).toMatch(/T/);
+      expect(item).toBeDefined();
+      expect(item!.attentionLane).toBe('review');
+      expect(item!.whySurfaced).toContain('review requested');
+      expect(item!.scoreBreakdown.weightedScore).toBe(item!.score);
+      expect(item!.freshnessCheckedAt).toBe(result.generatedAt);
+    });
+
+    it('should mark issues covered by open PRs explicitly', () => {
+      const issue = makeIssue({ number: 42, repo: 'fureworks/scope', ageDays: 20 });
+      const pr = makePR({ number: 9, title: 'Fix scope issue', body: 'Closes #42', ageDays: 20 });
+
+      const result = prioritize(
+        [makeGitSignal('scope', [pr])],
+        [], [], [issue], DEFAULT_WEIGHTS
+      );
+
+      const allItems = [...result.now, ...result.today];
+      const item = allItems.find(i => i.source === 'issue');
+      expect(item).toBeDefined();
+      expect(item!.coveredByOpenPr).toBe(true);
+      expect(item!.whySurfaced.some((entry) => entry.includes('covered by open PR'))).toBe(true);
+    });
+  });
+
   describe('issue scoring', () => {
     it('should include issues in output', () => {
       const issue = makeIssue({ number: 42, ageDays: 20 });

--- a/src/engine/prioritize.ts
+++ b/src/engine/prioritize.ts
@@ -5,6 +5,26 @@ import { isItemMuted } from "../store/muted.js";
 import { ScoringWeights, DEFAULT_WEIGHTS } from "../store/config.js";
 
 export type Priority = "now" | "today" | "later";
+export type AttentionLane = "review" | "merge" | "nudge" | "investigate";
+
+export interface ScoreBreakdown {
+  staleness: number;
+  blocking: number;
+  labels: number;
+  mergeReady: number;
+  timePressure: number;
+  effortMatch: number;
+  weightMultiplier: number;
+  weightedScore: number;
+}
+
+export interface RepoMomentum {
+  state: "active" | "quiet" | "stale";
+  lastCommitAgeHours: number;
+  uncommittedFiles: number;
+  openPrs: number;
+  staleBranches: number;
+}
 
 export interface ScoredItem {
   id: string; // machine-readable: "pr:repo#N", "issue:repo#N", "git:repo", "cal:title"
@@ -17,6 +37,14 @@ export interface ScoredItem {
   confidence: "high" | "medium" | "low";
   confidenceNote?: string;
   source: "git" | "calendar" | "pr" | "issue";
+  scoreBreakdown: ScoreBreakdown;
+  whySurfaced: string[];
+  repoMomentum?: RepoMomentum;
+  coveredByOpenPr: boolean;
+  blocked: boolean;
+  blockedReason?: string;
+  freshnessCheckedAt: string;
+  attentionLane: AttentionLane;
 }
 
 export interface PrioritizedOutput {
@@ -26,13 +54,15 @@ export interface PrioritizedOutput {
   readonly laterCount: number;
   freeBlocks: FreeBlock[];
   suggestions: string[];
+  mode: "ops-radar";
+  advisory: true;
+  generatedAt: string;
 }
 
 interface CandidateItem extends ScoredItem {
   suppressionReason?: string;
 }
 
-// Label patterns → score boost (case-insensitive substring match)
 const LABEL_BOOSTS: Array<{ pattern: string; boost: number }> = [
   { pattern: "p0", boost: 15 },
   { pattern: "critical", boost: 15 },
@@ -45,12 +75,33 @@ const LABEL_BOOSTS: Array<{ pattern: string; boost: number }> = [
   { pattern: "enhancement", boost: 2 },
 ];
 
+const OWNER_BLOCK_PATTERNS = [
+  /needs[- _]?owner/i,
+  /owner[- _]?decision/i,
+  /\bowner\b/i,
+  /needs[- _]?decision/i,
+  /\bdecision\b/i,
+  /\bapproval\b/i,
+  /needs[- _]?pm/i,
+  /\bproduct\b/i,
+];
+
+const INFRA_BLOCK_PATTERNS = [
+  /\binfra\b/i,
+  /environment/i,
+  /\benv\b/i,
+  /tooling/i,
+  /deployment/i,
+  /\bdeploy\b/i,
+  /\bci\b/i,
+  /ops/i,
+];
+
 function getLabelBoost(labels: string[]): number {
   let maxBoost = 0;
   for (const label of labels) {
     const lower = label.toLowerCase();
     for (const { pattern, boost } of LABEL_BOOSTS) {
-      // Word-boundary match: "p1" matches "p1-important" but not "p10"
       const re = new RegExp(`(^|[^a-z0-9])${pattern}($|[^a-z0-9])`);
       if (re.test(lower) && boost > maxBoost) {
         maxBoost = boost;
@@ -60,27 +111,117 @@ function getLabelBoost(labels: string[]): number {
   return maxBoost;
 }
 
-function scoreMyPR(pr: PRInfo, repoName: string): CandidateItem | null {
-  // Only surface if there's a review decision worth acting on
+function repoSlug(repo: string): string {
+  const parts = repo.split("/").filter(Boolean);
+  return parts[parts.length - 1] || repo;
+}
+
+function sameRepo(a: string, b: string): boolean {
+  return a === b || repoSlug(a) === repoSlug(b);
+}
+
+function buildRepoMomentum(signal?: GitSignal): RepoMomentum | undefined {
+  if (!signal) return undefined;
+  let state: RepoMomentum["state"] = "quiet";
+  if (signal.uncommittedFiles > 0 || signal.lastCommitAge <= 24) {
+    state = "active";
+  } else if (signal.lastCommitAge > 72 && signal.openPRs.length === 0) {
+    state = "stale";
+  }
+
+  return {
+    state,
+    lastCommitAgeHours: Math.round(signal.lastCommitAge * 10) / 10,
+    uncommittedFiles: signal.uncommittedFiles,
+    openPrs: signal.openPRs.length,
+    staleBranches: signal.staleBranches.length,
+  };
+}
+
+function createBreakdown(): ScoreBreakdown {
+  return {
+    staleness: 0,
+    blocking: 0,
+    labels: 0,
+    mergeReady: 0,
+    timePressure: 0,
+    effortMatch: 0,
+    weightMultiplier: 1,
+    weightedScore: 0,
+  };
+}
+
+function detectBlocked(labels: string[]): { blocked: boolean; blockedReason?: string } {
+  if (labels.some((label) => OWNER_BLOCK_PATTERNS.some((pattern) => pattern.test(label)))) {
+    return {
+      blocked: true,
+      blockedReason: "Waiting on owner decision.",
+    };
+  }
+
+  if (labels.some((label) => INFRA_BLOCK_PATTERNS.some((pattern) => pattern.test(label)))) {
+    return {
+      blocked: true,
+      blockedReason: "Waiting on environment or tooling.",
+    };
+  }
+
+  return { blocked: false };
+}
+
+function findCoveringPr(issue: IssueSignal, gitSignals: GitSignal[]): PRInfo | undefined {
+  const signal = gitSignals.find((candidate) => sameRepo(candidate.repo, issue.repo));
+  if (!signal) return undefined;
+
+  const patterns = [
+    new RegExp(`(^|\\W)#${issue.number}(\\b|$)`),
+    new RegExp(`/issues/${issue.number}(\\b|$)`),
+  ];
+
+  return signal.openPRs.find((pr) => {
+    const haystack = `${pr.title}\n${pr.body ?? ""}`;
+    return patterns.some((pattern) => pattern.test(haystack));
+  });
+}
+
+function scoreMyPR(pr: PRInfo, repoName: string, repoSignal: GitSignal | undefined, freshnessCheckedAt: string): CandidateItem | null {
   if (!pr.reviewDecision || pr.reviewDecision === "REVIEW_REQUIRED") return null;
 
   let score = 0;
   let reason = "";
   const details: string[] = [];
+  const whySurfaced: string[] = [];
+  const scoreBreakdown = createBreakdown();
+  let blocked = false;
+  let blockedReason: string | undefined;
+  let attentionLane: AttentionLane = "investigate";
 
   if (pr.reviewDecision === "CHANGES_REQUESTED") {
-    score = 28; // High — someone reviewed and wants changes
+    score = 28;
+    scoreBreakdown.blocking += 28;
     reason = "Changes requested on your PR. Respond to reviewer.";
+    blocked = true;
+    blockedReason = "Changes requested on the PR.";
     details.push("changes requested");
+    whySurfaced.push("changes requested");
+    attentionLane = "investigate";
   } else if (pr.reviewDecision === "APPROVED") {
-    score = 18; // Medium — ready to merge, don't let it sit
+    score = 18;
+    scoreBreakdown.mergeReady += 18;
     reason = "Your PR is approved. Merge it.";
     details.push("approved, ready to merge");
+    whySurfaced.push("approved and ready to merge");
+    attentionLane = "merge";
   }
 
   if (pr.ciStatus === "fail") {
     score += 5;
+    scoreBreakdown.blocking += 5;
+    blocked = true;
+    blockedReason = "CI is failing.";
     details.push("CI failing");
+    whySurfaced.push("failing CI");
+    attentionLane = "investigate";
   }
 
   if (score === 0) return null;
@@ -98,52 +239,81 @@ function scoreMyPR(pr: PRInfo, repoName: string): CandidateItem | null {
     confidence: "high" as const,
     source: "pr",
     suppressionReason: undefined,
+    scoreBreakdown,
+    whySurfaced,
+    repoMomentum: buildRepoMomentum(repoSignal),
+    coveredByOpenPr: false,
+    blocked,
+    blockedReason,
+    freshnessCheckedAt,
+    attentionLane,
   };
 }
 
-function scorePR(pr: PRInfo, repoName: string): CandidateItem {
+function scorePR(pr: PRInfo, repoName: string, repoSignal: GitSignal | undefined, freshnessCheckedAt: string): CandidateItem {
   let score = 0;
   const details: string[] = [];
+  const whySurfaced: string[] = [];
+  const scoreBreakdown = createBreakdown();
   const ageDaysRounded = Math.round(pr.ageDays);
+  let blocked = false;
+  let blockedReason: string | undefined;
+  let attentionLane: AttentionLane = "nudge";
 
-  // Graduated staleness — scales with age, not step-function
   let agePoints = 0;
   if (pr.ageDays > 2) {
     agePoints = Math.min(30, Math.round(pr.ageDays * 0.6));
     score += agePoints;
+    scoreBreakdown.staleness += agePoints;
     details.push(`open ${ageDaysRounded} days`);
+    whySurfaced.push(`open ${ageDaysRounded} days`);
   }
 
-  // Blocking potential (scaled up proportionally)
   const reviewPoints = pr.reviewRequested ? 15 : 0;
   const ciPoints = pr.ciStatus === "fail" ? 10 : 0;
   const conflictPoints = pr.hasConflicts ? 8 : 0;
 
   if (pr.reviewRequested) {
     score += reviewPoints;
+    scoreBreakdown.blocking += reviewPoints;
     details.push("review requested");
+    whySurfaced.push("review requested");
+    attentionLane = "review";
   }
   if (pr.ciStatus === "fail") {
     score += ciPoints;
+    scoreBreakdown.blocking += ciPoints;
+    blocked = true;
+    blockedReason = "CI is failing.";
     details.push("CI failing");
+    whySurfaced.push("failing CI");
+    attentionLane = "investigate";
   }
   if (pr.hasConflicts) {
     score += conflictPoints;
+    scoreBreakdown.blocking += conflictPoints;
+    blocked = true;
+    blockedReason = "Merge conflicts detected.";
     details.push("has conflicts");
+    whySurfaced.push("merge conflicts");
+    attentionLane = "investigate";
   }
 
-  // Label-based boost (#23, #25)
   const labelBoost = getLabelBoost(pr.labels ?? []);
   if (labelBoost > 0) {
     score += labelBoost;
+    scoreBreakdown.labels += labelBoost;
     details.push("priority label");
+    whySurfaced.push(`priority label: ${(pr.labels ?? []).join(", ")}`);
   }
 
-  // APPROVED + MERGEABLE boost — free value waiting to be captured
   const approvedBoost = pr.reviewDecision === "APPROVED" && !pr.hasConflicts ? 20 : 0;
   if (approvedBoost > 0) {
     score += approvedBoost;
+    scoreBreakdown.mergeReady += approvedBoost;
     details.push("approved, ready to merge");
+    whySurfaced.push("approved and ready to merge");
+    attentionLane = "merge";
   }
 
   let reason = "Needs attention.";
@@ -159,7 +329,7 @@ function scorePR(pr: PRInfo, repoName: string): CandidateItem {
     } else {
       reason = `Open ${ageDaysRounded} days.`;
     }
-  } else if (ciPoints >= conflictPoints) {
+  } else if (ciPoints >= conflictPoints && ciPoints > 0) {
     reason = "CI is failing. Fix or close.";
   } else if (conflictPoints > 0) {
     reason = "Merge conflicts detected. Rebase or close.";
@@ -167,7 +337,6 @@ function scorePR(pr: PRInfo, repoName: string): CandidateItem {
     reason = "Approved and ready to merge. Ship it.";
   }
 
-  // Updated thresholds for wider score range
   const priority: Priority = score >= 25 ? "now" : score >= 12 ? "today" : "later";
 
   const suppressionReason =
@@ -179,8 +348,6 @@ function scorePR(pr: PRInfo, repoName: string): CandidateItem {
           : undefined
       : undefined;
 
-  // Confidence: check for thin data
-  // Fix #22: don't say "no reviewer assigned" when reviewDecision exists
   const missingContext: string[] = [];
   if (pr.ciStatus === "unknown") missingContext.push("no CI status");
   if (!pr.reviewRequested && !pr.reviewDecision && pr.ageDays > 2) {
@@ -200,37 +367,54 @@ function scorePR(pr: PRInfo, repoName: string): CandidateItem {
     confidenceNote: missingContext.length > 0 ? `low context: ${missingContext.join(", ")}` : undefined,
     source: "pr",
     suppressionReason,
+    scoreBreakdown,
+    whySurfaced,
+    repoMomentum: buildRepoMomentum(repoSignal),
+    coveredByOpenPr: false,
+    blocked,
+    blockedReason,
+    freshnessCheckedAt,
+    attentionLane,
   };
 }
 
-function scoreRepoWork(signal: GitSignal): CandidateItem | null {
+function scoreRepoWork(signal: GitSignal, freshnessCheckedAt: string): CandidateItem | null {
   if (signal.uncommittedFiles === 0) return null;
 
   let score = 0;
   const details: string[] = [];
+  const whySurfaced: string[] = [];
+  const scoreBreakdown = createBreakdown();
 
   details.push(
     `${signal.uncommittedFiles} uncommitted file${signal.uncommittedFiles > 1 ? "s" : ""}`
   );
+  whySurfaced.push(`${signal.uncommittedFiles} uncommitted file${signal.uncommittedFiles > 1 ? "s" : ""}`);
 
-  // Staleness of uncommitted work (scaled to new range)
   const days = Math.round(signal.lastCommitAge / 24);
   let reason = "Uncommitted changes detected.";
   if (signal.lastCommitAge > 72) {
-    score += 28; // 3+ days uncommitted = NOW
+    score += 28;
+    scoreBreakdown.staleness += 28;
     details.push(`last commit ${days}d ago`);
+    whySurfaced.push(`last commit ${days}d ago`);
     reason = `Uncommitted work for ${days} days. Commit or stash.`;
   } else if (signal.lastCommitAge > 24) {
-    score += 18; // 1-3 days = TODAY
+    score += 18;
+    scoreBreakdown.staleness += 18;
     details.push(`last commit ${days}d ago`);
+    whySurfaced.push(`last commit ${days}d ago`);
     reason = `Uncommitted work for ${days} days. Commit or stash.`;
   } else if (signal.lastCommitAge > 4) {
     const hours = Math.round(signal.lastCommitAge);
-    score += 8; // 4+ hours = low TODAY
+    score += 8;
+    scoreBreakdown.staleness += 8;
     details.push(`last touched ${hours}h ago`);
+    whySurfaced.push(`last touched ${hours}h ago`);
     reason = `Uncommitted work for ${hours} hours. Commit or stash.`;
   } else {
     score += 3;
+    scoreBreakdown.staleness += 3;
   }
 
   const priority: Priority = score >= 25 ? "now" : score >= 12 ? "today" : "later";
@@ -243,31 +427,47 @@ function scoreRepoWork(signal: GitSignal): CandidateItem | null {
     label: `${signal.repo}`,
     detail: details.join(", "),
     reason,
-    confidence: "high" as const, // git signals are always concrete
+    confidence: "high" as const,
     source: "git",
     suppressionReason:
       priority === "later" ? "Recently touched, nothing stale" : undefined,
+    scoreBreakdown,
+    whySurfaced,
+    repoMomentum: buildRepoMomentum(signal),
+    coveredByOpenPr: false,
+    blocked: false,
+    freshnessCheckedAt,
+    attentionLane: "investigate",
   };
 }
 
-function scoreCalendarEvent(event: CalendarEvent): ScoredItem | null {
-  // Only surface upcoming events (not past ones)
+function scoreCalendarEvent(event: CalendarEvent, freshnessCheckedAt: string): ScoredItem | null {
   if (event.minutesUntilStart < -15) return null;
 
   let score = 0;
   let reason = "Upcoming calendar event.";
+  const whySurfaced: string[] = [];
+  const scoreBreakdown = createBreakdown();
 
   if (event.minutesUntilStart <= 0 && event.minutesUntilStart > -15) {
-    score += 30; // Happening now = always NOW
+    score += 30;
+    scoreBreakdown.timePressure += 30;
     reason = "Happening now.";
+    whySurfaced.push("happening now");
   } else if (event.minutesUntilStart <= 30) {
-    score += 28; // <30 min = NOW
+    score += 28;
+    scoreBreakdown.timePressure += 28;
     reason = `Starting in ${event.minutesUntilStart} minutes.`;
+    whySurfaced.push(`starts in ${event.minutesUntilStart} minutes`);
   } else if (event.minutesUntilStart <= 60) {
-    score += 20; // <60 min = TODAY (high)
+    score += 20;
+    scoreBreakdown.timePressure += 20;
     reason = `Starting in ${event.minutesUntilStart} minutes.`;
+    whySurfaced.push(`starts in ${event.minutesUntilStart} minutes`);
   } else {
-    score += 14; // >60 min = TODAY (low)
+    score += 14;
+    scoreBreakdown.timePressure += 14;
+    whySurfaced.push(`starts in ${event.minutesUntilStart} minutes`);
   }
 
   const priority: Priority = score >= 25 ? "now" : "today";
@@ -292,34 +492,50 @@ function scoreCalendarEvent(event: CalendarEvent): ScoredItem | null {
     label: `Meeting: ${event.title}`,
     detail: timeLabel,
     reason,
-    confidence: "high" as const, // calendar events are factual
+    confidence: "high" as const,
     source: "calendar",
+    scoreBreakdown,
+    whySurfaced,
+    coveredByOpenPr: false,
+    blocked: false,
+    freshnessCheckedAt,
+    attentionLane: "investigate",
   };
 }
 
-function scoreIssue(issue: IssueSignal): CandidateItem {
+function scoreIssue(issue: IssueSignal, gitSignals: GitSignal[], freshnessCheckedAt: string): CandidateItem {
   let score = 0;
   const details: string[] = [];
+  const whySurfaced: string[] = [];
+  const scoreBreakdown = createBreakdown();
   const ageDaysRounded = Math.round(issue.ageDays);
 
-  // Graduated staleness — same as PRs
   let agePoints = 0;
   if (issue.ageDays > 2) {
     agePoints = Math.min(30, Math.round(issue.ageDays * 0.6));
     score += agePoints;
+    scoreBreakdown.staleness += agePoints;
     details.push(`open ${ageDaysRounded} days`);
+    whySurfaced.push(`open ${ageDaysRounded} days`);
   }
 
-  // Label-based boost (reuses same LABEL_BOOSTS as PRs)
   const labelBoost = getLabelBoost(issue.labels);
   if (labelBoost > 0) {
     score += labelBoost;
+    scoreBreakdown.labels += labelBoost;
     details.push("priority label");
+    whySurfaced.push(`priority label: ${issue.labels.join(", ")}`);
   }
 
+  const coveringPr = findCoveringPr(issue, gitSignals);
+  if (coveringPr) {
+    whySurfaced.push(`covered by open PR #${coveringPr.number}`);
+  }
+
+  const blockedState = detectBlocked(issue.labels);
   const priority: Priority = score >= 25 ? "now" : score >= 12 ? "today" : "later";
   const labels = issue.labels.length > 0 ? ` [${issue.labels.join(", ")}]` : "";
-  
+
   let reason = "Issue needs attention.";
   if (agePoints > labelBoost && agePoints > 0) {
     reason = `Open ${ageDaysRounded} days. Getting stale.`;
@@ -328,10 +544,14 @@ function scoreIssue(issue: IssueSignal): CandidateItem {
     reason = `Marked ${topLabel}. Needs attention.`;
   }
 
-  // Confidence: issues missing labels
+  if (blockedState.blockedReason) {
+    reason = blockedState.blockedReason;
+  }
+
   const issueMissing: string[] = [];
   if (issue.labels.length === 0) issueMissing.push("no labels");
   const issueConfidence: ScoredItem["confidence"] = issueMissing.length > 0 ? "medium" : "high";
+  const repoSignal = gitSignals.find((signal) => sameRepo(signal.repo, issue.repo));
 
   return {
     priority,
@@ -348,6 +568,14 @@ function scoreIssue(issue: IssueSignal): CandidateItem {
       priority === "later" && issue.ageDays < 7 && labelBoost === 0
         ? "Less than a week old, no priority label"
         : undefined,
+    scoreBreakdown,
+    whySurfaced,
+    repoMomentum: buildRepoMomentum(repoSignal),
+    coveredByOpenPr: Boolean(coveringPr),
+    blocked: blockedState.blocked,
+    blockedReason: blockedState.blockedReason,
+    freshnessCheckedAt,
+    attentionLane: blockedState.blocked ? "investigate" : "nudge",
   };
 }
 
@@ -358,77 +586,71 @@ export function prioritize(
   issues: IssueSignal[],
   weights: ScoringWeights = DEFAULT_WEIGHTS
 ): PrioritizedOutput {
+  const generatedAt = new Date().toISOString();
   const allItems: CandidateItem[] = [];
 
-  // Score calendar events
   for (const event of calendarEvents) {
-    const scored = scoreCalendarEvent(event);
+    const scored = scoreCalendarEvent(event, generatedAt);
     if (scored) allItems.push(scored);
   }
 
-  // Score git repos
   for (const signal of gitSignals) {
-    // Score uncommitted work
     const gitItemId = `git:${signal.repo}`;
-    const repoItem = isItemMuted(gitItemId) ? null : scoreRepoWork(signal);
+    const repoItem = isItemMuted(gitItemId) ? null : scoreRepoWork(signal, generatedAt);
     if (repoItem) allItems.push(repoItem);
 
-    // Score PRs (in the repo)
     for (const pr of signal.openPRs) {
       const prItemId = `pr:${signal.repo}#${pr.number}`;
       if (isItemMuted(prItemId)) continue;
-      allItems.push(scorePR(pr, signal.repo));
+      allItems.push(scorePR(pr, signal.repo, signal, generatedAt));
     }
 
-    // Score my PRs with inbound reviews
     for (const pr of signal.myPRs) {
-      // Skip if already scored as an open PR (dedup)
       const prItemId = `mypr:${signal.repo}#${pr.number}`;
       const alreadyScored = signal.openPRs.some((p) => p.number === pr.number);
       if (alreadyScored || isItemMuted(prItemId)) continue;
-      const scored = scoreMyPR(pr, signal.repo);
+      const scored = scoreMyPR(pr, signal.repo, signal, generatedAt);
       if (scored) allItems.push(scored);
     }
   }
 
-  // Score issues
   for (const issue of issues) {
     const issueItemId = `issue:${issue.repo}#${issue.number}`;
     if (isItemMuted(issueItemId)) continue;
-    const scored = scoreIssue(issue);
+    const scored = scoreIssue(issue, gitSignals, generatedAt);
     if (scored) allItems.push(scored);
   }
 
-  // Apply weight multipliers based on source type
   for (const item of allItems) {
+    let weightMultiplier = 1;
     if (item.source === "git") {
-      item.score = Math.round(item.score * weights.staleness);
+      weightMultiplier = weights.staleness;
     } else if (item.source === "pr") {
-      // PRs have both staleness and blocking components — use the higher weight
-      item.score = Math.round(item.score * Math.max(weights.staleness, weights.blocking));
+      weightMultiplier = Math.max(weights.staleness, weights.blocking);
     } else if (item.source === "calendar") {
-      item.score = Math.round(item.score * weights.timePressure);
+      weightMultiplier = weights.timePressure;
     } else if (item.source === "issue") {
-      item.score = Math.round(item.score * weights.staleness);
+      weightMultiplier = weights.staleness;
     }
-    // Recalculate priority tier after weight adjustment
+
+    item.scoreBreakdown.weightMultiplier = weightMultiplier;
+    item.score = Math.round(item.score * weightMultiplier);
+    item.scoreBreakdown.weightedScore = item.score;
     item.priority = item.score >= 25 ? "now" : item.score >= 12 ? "today" : "later";
 
-    // P0/critical/blocker floor: never lower than TODAY
     if (item.priority === "later" && item.detail?.includes("priority label")) {
       const hasHighPriorityLabel = (item.source === "pr" || item.source === "issue") &&
         item.detail?.match(/\b(P0|critical|blocker|security|compliance)\b/i);
       if (hasHighPriorityLabel) {
         item.priority = "today";
         item.score = Math.max(item.score, 12);
+        item.scoreBreakdown.weightedScore = item.score;
       }
     }
   }
 
-  // Sort by score descending
   allItems.sort((a, b) => b.score - a.score);
 
-  // Cap output: max 3 NOW items, max 5 TODAY items. Rest goes to later.
   const allNow = allItems.filter((i) => i.priority === "now");
   const allToday = allItems.filter((i) => i.priority === "today");
   const allLater = allItems.filter((i) => i.priority === "later");
@@ -448,7 +670,6 @@ export function prioritize(
     })),
   ];
 
-  // Generate suggestions
   const suggestions: string[] = [];
   if (freeBlocks.length > 0) {
     const biggestBlock = freeBlocks.reduce((a, b) =>
@@ -466,7 +687,6 @@ export function prioritize(
     const mins = biggestBlock.durationMinutes % 60;
     const durationStr = hours > 0 ? `${hours}h${mins > 0 ? `${mins}m` : ""}` : `${mins}m`;
 
-    // Find a good item to suggest for this block
     const deepWorkItem = today.find((i) => i.source === "git");
     if (deepWorkItem) {
       suggestions.push(
@@ -488,5 +708,8 @@ export function prioritize(
     },
     freeBlocks,
     suggestions,
+    mode: "ops-radar",
+    advisory: true,
+    generatedAt,
   };
 }

--- a/src/sources/git.ts
+++ b/src/sources/git.ts
@@ -15,6 +15,7 @@ export interface PRInfo {
   number: number;
   title: string;
   url: string;
+  body?: string;
   ageDays: number;
   reviewRequested: boolean;
   reviewDecision: string; // APPROVED, REVIEW_REQUIRED, CHANGES_REQUESTED, or ""
@@ -120,7 +121,7 @@ async function getOpenPRs(repoPath: string): Promise<PRInfo[]> {
     const execAsync = promisify(exec);
 
     const { stdout } = await execAsync(
-      `gh pr list --json number,title,url,createdAt,reviewRequests,reviewDecision,statusCheckRollup,mergeable,labels --limit 10`,
+      `gh pr list --json number,title,url,body,createdAt,reviewRequests,reviewDecision,statusCheckRollup,mergeable,labels --limit 10`,
       {
         cwd: repoPath,
         encoding: "utf-8",
@@ -132,6 +133,7 @@ async function getOpenPRs(repoPath: string): Promise<PRInfo[]> {
       number: number;
       title: string;
       url: string;
+      body?: string;
       createdAt: string;
       reviewRequests: Array<{ login?: string }>;
       reviewDecision: string;
@@ -169,6 +171,7 @@ async function getOpenPRs(repoPath: string): Promise<PRInfo[]> {
         number: pr.number,
         title: pr.title,
         url: pr.url,
+        body: pr.body,
         ageDays: Math.round(ageDays * 10) / 10,
         reviewRequested,
         reviewDecision,
@@ -190,7 +193,7 @@ async function getMyPRs(repoPath: string): Promise<PRInfo[]> {
     const execAsync = promisify(exec);
 
     const { stdout } = await execAsync(
-      `gh pr list --author @me --state open --json number,title,url,createdAt,reviewRequests,reviewDecision,statusCheckRollup,mergeable,labels --limit 10`,
+      `gh pr list --author @me --state open --json number,title,url,body,createdAt,reviewRequests,reviewDecision,statusCheckRollup,mergeable,labels --limit 10`,
       {
         cwd: repoPath,
         encoding: "utf-8",
@@ -202,6 +205,7 @@ async function getMyPRs(repoPath: string): Promise<PRInfo[]> {
       number: number;
       title: string;
       url: string;
+      body?: string;
       createdAt: string;
       reviewRequests: Array<{ login?: string }>;
       reviewDecision: string;
@@ -232,6 +236,7 @@ async function getMyPRs(repoPath: string): Promise<PRInfo[]> {
         number: pr.number,
         title: pr.title,
         url: pr.url,
+        body: pr.body,
         ageDays: Math.round(ageDays * 10) / 10,
         reviewRequested:
           pr.reviewRequests.length > 0 ||


### PR DESCRIPTION
## Summary
- add stable ops-radar metadata to `scope today --json`, including score breakdowns, lanes, blocker state, coverage hints, repo momentum, and freshness timestamps
- expose PR body context so issue coverage by open PR can be detected in advisory output
- update README and workflow docs to frame Scope as advisory ops radar, not the build selector

## Testing
- npm test
- npm run build

Closes #35
